### PR TITLE
Pull from the LV calendar proper

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ All cover images must be shared with the application's service account; either b
   ```html
   <!-- This bit should be placed within an "embed" block over on ye 'ole Squarespace -->
   <div>
-    <iframe id="lv-events-embed" width="100%" src="https://events.losverd.es/" scrolling="no"></iframe>
+    <iframe id="lv-events-embed" height="800px" width="100%" src="https://events.losverd.es/" scrolling="no"></iframe>
   </div>
   ```
 

--- a/events_page/apis/constants.py
+++ b/events_page/apis/constants.py
@@ -6,14 +6,14 @@ class CalendarColors(metaclass=Singleton):
     _event_colors = {
         "unset": {"background": None, "id": "0"},
         "banana": {"background": "#f6c026", "id": "5"},
-        "sage": {"background": "#0b8043", "id": "10"},
+        "sage": {"background": "#0b8043", "id": "2"},
         "blueberry": {"background": "#3f51b5", "id": "9"},
         "flamingo": {"background": "#e67c73", "id": "4"},
         "grape": {"background": "#8e24aa", "id": "3"},
         "graphite": {"background": "#616161", "id": "8"},
         "lavender": {"background": "#a4bdfc", "id": "1"},
         "peacock": {"background": "#039be5", "id": "7"},
-        "basil": {"background": "#33b679", "id": "2"},
+        "basil": {"background": "#33b679", "id": "10"},
         "tangerine": {"background": "#f5511d", "id": "6"},
         "tomato": {"background": "#d60000", "id": "11"},
     }

--- a/events_page/static/scss/style.scss
+++ b/events_page/static/scss/style.scss
@@ -12,6 +12,11 @@ $bright-verde: #0bac44;
   }
 }
 
+.mdl-tooltip {
+  font-size: 24px;
+  line-height: 24px;
+}
+
 .event-card.mdl-card {
   width: 100%;
 
@@ -77,15 +82,8 @@ input[type="radio"] {
   display: block;
 }
 
-[value="all"]:checked ~ .empty-cards [data-category] {
-  display: none;
-}
-
 @each $category_name in $category_names {
   [value="#{$category_name}"]:checked ~ .event-cards .mdl-cell:not([data-category~="#{$category_name}"]) {
-    display: none;
-  }
-  [value="#{$category_name}"]:checked ~ .empty-cards .mdl-cell:not([data-category~="#{$category_name}"]) {
     display: none;
   }
 }
@@ -98,6 +96,9 @@ input[type="radio"] {
   [value="#{$category_name}"]:checked ~ .filters [for="#{$category_name}"] {
     background: $bright-verde;
     color: white;
+  }
+  [value="#{$category_name}"]:disabled ~ .filters [for="#{$category_name}"] {
+    color: gray;
   }
 }
 

--- a/events_page/static/scss/style.scss
+++ b/events_page/static/scss/style.scss
@@ -18,6 +18,10 @@ $bright-verde: #0bac44;
     height: 176px;
   }
 
+  .event-date {
+    padding-left: 10px;
+  }
+
   .expandable-content {
     display: none;
     overflow: hidden;
@@ -30,11 +34,6 @@ $bright-verde: #0bac44;
   mark {
     background-color: rgba(0, 0, 0, 0.5);
     color: rgb(255, 255, 255);
-  }
-
-  small {
-    opacity: 1;
-    font-size: medium;
   }
 
   summary {

--- a/events_page/static/scss/style.scss
+++ b/events_page/static/scss/style.scss
@@ -6,10 +6,11 @@ $bright-verde: #0bac44;
   padding-right: 4px;
 }
 
-// mark {
-//   background-color: rgba(0, 0, 0, 0);
-// }
-
+.lv-header.mdl-layout--fixed-header {
+  > header {
+    background-color: $bright-verde;
+  }
+}
 
 .event-card.mdl-card {
   width: 100%;

--- a/events_page/templates/event_card.html
+++ b/events_page/templates/event_card.html
@@ -5,9 +5,10 @@
     class="mdl-card mdl-shadow--2dp event-card {{ event.css_classes | default([]) | join(' ') }}{% if event.is_match %} event-card-{{ event.match_slug }}{% endif %}">
     <div class="mdl-card__title mdl-card--expand">
       <h4>
-        <mark>{{ event.summary }}</mark>
+        <mark class="event-summary">{{ event.summary }}</mark>
         </br>
-        <mark><small>{{ event.start_dt.strftime('%b %d') }} @ {{ event.start_dt.strftime('%I:%M %p') }}</small></mark>
+        <mark class="event-date">{{ event.start_dt.strftime('%b %d') }} @
+          {{ event.start_dt.strftime('%I:%M %p') }}</mark>
       </h4>
     </div>
     <div class="mdl-card__supporting-text">

--- a/events_page/templates/index.html
+++ b/events_page/templates/index.html
@@ -72,9 +72,11 @@
     </div>
     <main class="mdl-layout__content">
       <div class="page-content">
+
         <input type="radio" id="all" name="categories" value="all" checked>
         {% for category in calendar.default_category_names + calendar.additional_category_names %}
-        <input type="radio" id="{{ category }}" name="categories" value="{{ category }}">
+        <input type="radio" id="{{ category }}" name="categories" value="{{ category }}" {% if category in
+          calendar.empty_category_names %}disabled{% endif %}>
         {% endfor %}
         <ol class="filters">
           <li>
@@ -84,9 +86,17 @@
           </li>
           {% for category in calendar.default_category_names + calendar.additional_category_names %}
           <li>
-            <label class="mdl-chip" for="{{ category }}">
+            <label id="{{ category }}-label" class="mdl-chip" for="{{ category }}">
               <span class="mdl-chip__text">{{ category }}</span>
             </label>
+            {% if category in calendar.empty_category_names %}
+            <div class="mdl-tooltip" data-mdl-for="{{ category }}-label">
+              No events currently on the calendar for:
+              <pre>{{ category }}</pre>
+              <br>
+              Please check back later! 🖤💚
+            </div>
+            {% endif %}
           </li>
           {% endfor %}
         </ol>
@@ -95,26 +105,10 @@
           {{ macro.event_card(event) }}
           {% endfor %}
         </div>
-
-        <div class="mdl-grid empty-cards">
-          <!-- <div class="mdl-layout-spacer"></div> -->
-          {% for empty_category in calendar.empty_category_names %}
-          <div class="mdl-cell mdl-cell--12-col empty-category" data-category="{{ empty_category }}">
-            <div class="empty-event-card mdl-card mdl-shadow--2dp">
-              <div class="mdl-card__title mdl-card--expand">
-                <h4>
-                  No upcoming calendar events for <b>{{ empty_category }}</b>...
-                </h4>
-              </div>
-            </div>
-          </div>
-          {% endfor %}
-        </div>
       </div>
-    </main>
-    <!-- <footer class="mdl-mega-footer">
-      {% block footer %}{% endblock %}
-    </footer> -->
+
+  </div>
+  </main>
   </div>
 </body>
 

--- a/events_page/templates/index.html
+++ b/events_page/templates/index.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <!-- <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.grey-green.min.css" /> -->
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.green-light_green.min.css" />
+  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" type="text/css">
 
 
   {% assets "style" %}

--- a/events_page/templates/index.html
+++ b/events_page/templates/index.html
@@ -26,7 +26,7 @@
 
 <body>
 
-  <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
+  <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header lv-header">
     <header class="mdl-layout__header">
       <div class="mdl-layout__header-row">
         <!-- Title -->

--- a/losverdesatx-events.tfvars
+++ b/losverdesatx-events.tfvars
@@ -1,6 +1,5 @@
-# calendar_id               = "information@losverdesatx.org"
 # gcp_billing_account_name = "Los Verdes"
-calendar_id            = "tnf6pf0ucprlk8hr9loas1vp74@group.calendar.google.com"
+calendar_id            = "information@losverdesatx.org"
 cloudflare_zone        = "losverd.es"
 gcp_billing_account_id = "019767-2A54C9-AE07C6"
 gcp_project_editors    = []

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -21,7 +21,7 @@ module "github_oidc" {
   attribute_condition = "assertion.repository=='${var.github_repo}'"
   sa_mapping = {
     "gh-test-runner" = {
-      sa_name   = google_service_account.test_site_publisher.name
+      sa_name = google_service_account.test_site_publisher.name
       # TODO: figure out how to cover our pr test, etc. workflwos without being this broad
       attribute = "*"
     }

--- a/x/embed.html
+++ b/x/embed.html
@@ -1,4 +1,4 @@
 <!-- This bit should be placed within an "embed" block over on ye 'ole Squarespace -->
 <div>
-  <iframe id="lv-events-embed" width="100%" height="800px" src="http://192.168.86.31:5000/events" scrolling="no"></iframe>
+  <iframe id="lv-events-embed" height="800px" width="100%" src="https://events.losverd.es/" scrolling="no"></iframe>
 </div>


### PR DESCRIPTION
For proper styling, given current settings and whatnot, we should do the following before/after merging this in:

- [x] Add `site-publisher@losverdesatx-events.iam.gserviceaccount.com` and `test-site-publisher@losverdesatx-events.iam.gserviceaccount.com` to  `information@losverdesatx.org` calendar with "Manage events" access.
- [x] Update calendar event colors:
    - `los-verdes` category -> `Sage`
    - `la-murga` category -> `Graphite`
    - `home-games` category -> `Grape`
    - `away-games` category -> `Flamingo`